### PR TITLE
refreshed view of meeting card, removed summary preview.

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -523,10 +523,6 @@ nav a {
   white-space: nowrap;
 }
 
-.catalog-tag-overflow {
-  color: var(--color-secondary);
-}
-
 .agenda-card,
 .bookmark-card,
 .summary-card {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -289,7 +289,7 @@ nav a {
   border-radius: 10px;
   padding: 1rem;
   background-color: var(--color-card-bg);
-  border: 2px solid var(--color-secondary);
+  border: 1px solid var(--color-border);
   box-shadow: 0 16px 32px rgba(0, 0, 0, 0.08);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
@@ -308,8 +308,8 @@ nav a {
 
 .video-card:hover {
   cursor: pointer;
-  transform: translate(-10px);
-  box-shadow: 10px 10px 20px 0 var(--color-card-hover-shadow);
+  transform: translateY(-2px);
+  box-shadow: 0 18px 32px var(--color-card-hover-shadow);
 }
 
 .video-card:focus-visible {
@@ -357,14 +357,28 @@ nav a {
   padding: 0;
   flex: 0 0 100%;
   max-width: 100%;
+  overflow: hidden;
+  border-radius: 10px;
+  background-color: var(--color-surface-muted);
 }
 
 .catalog-thumbnail img {
   display: block;
   width: 100%;
   max-width: 100%;
-  border-radius: 10px;
+  aspect-ratio: 16 / 9;
+  border-radius: inherit;
   object-fit: cover;
+}
+
+.catalog-thumbnail-fallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  color: var(--color-text-soft);
+  font-weight: 700;
 }
 
 .catalog-play-icon {
@@ -375,6 +389,8 @@ nav a {
   inset: 0;
   font-size: 3rem;
   color: white;
+  background: linear-gradient(180deg, transparent 30%, rgba(0, 0, 0, 0.24));
+  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.35);
 }
 
 .catalog-video-card {
@@ -391,33 +407,62 @@ nav a {
 }
 
 .catalog-video-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  justify-content: space-between;
   min-width: 0;
 }
 
 .catalog-video-date {
-  margin-bottom: 0;
+  margin-bottom: 0.35rem;
+  color: var(--color-secondary);
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.catalog-video-title {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--color-text);
+  font-size: clamp(1.25rem, 2vw, 1.75rem);
+  line-height: 1.15;
+  text-overflow: ellipsis;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
 .catalog-video-subtitle {
   color: var(--color-text-soft);
   font-size: 0.95rem;
   line-height: 1.4;
-  margin-bottom: 0.75rem;
-}
-
-.catalog-summary-preview {
-  min-width: 0;
-  align-items: center;
-}
-
-.catalog-summary-preview-text {
-  color: var(--color-text-soft);
   display: -webkit-box;
-  -webkit-line-clamp: 6;
-  -webkit-box-orient: vertical;
+  margin-top: 0.65rem;
   overflow: hidden;
   text-overflow: ellipsis;
-  line-height: 1.5;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+}
+
+.catalog-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.9rem;
+  min-width: 0;
+}
+
+.catalog-watch-cue {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--color-secondary);
+  font-size: 0.9rem;
+  font-weight: 800;
+  white-space: nowrap;
 }
 
 .header-controls {
@@ -457,20 +502,29 @@ nav a {
 
 .catalog-tag-list {
   align-items: center;
+  min-width: 0;
 }
 
 .catalog-tag {
   display: inline-flex;
   align-items: center;
-  padding: 0.35rem 0.7rem;
+  max-width: 10rem;
+  padding: 0.3rem 0.6rem;
   border-radius: 999px;
   background-color: color-mix(in srgb, var(--color-secondary) 18%, var(--color-surface));
   border: 1px solid color-mix(in srgb, var(--color-secondary) 28%, var(--color-border));
   color: var(--color-text);
+  overflow: hidden;
   font-size: 0.72rem;
   font-weight: 700;
   letter-spacing: 0.03em;
+  text-overflow: ellipsis;
   text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.catalog-tag-overflow {
+  color: var(--color-secondary);
 }
 
 .agenda-card,
@@ -566,7 +620,7 @@ nav a {
 @media (min-width: 992px) {
   .catalog-video-card-layout {
     display: grid;
-    grid-template-columns: minmax(260px, 1.2fr) minmax(0, 1fr) minmax(260px, 1fr);
+    grid-template-columns: minmax(220px, 0.38fr) minmax(0, 1fr);
     align-items: stretch;
     gap: 1.25rem;
   }
@@ -577,12 +631,12 @@ nav a {
 
   .catalog-thumbnail img {
     height: 100%;
-    min-height: 180px;
+    min-height: 150px;
   }
 
-  .catalog-summary-preview {
-    padding: 0.25rem 0;
-    overflow: hidden;
+  .catalog-thumbnail-fallback {
+    height: 100%;
+    min-height: 150px;
   }
 }
 

--- a/frontend/src/pages/AboutPage.jsx
+++ b/frontend/src/pages/AboutPage.jsx
@@ -1,8 +1,8 @@
 const teamMembers = [
-    'Alwin Ray Roble',
     'Alexander Leontiev',
     'Thomas Scott',
     'Nikita Ulianov',
+    'Alwin Ray Roble'
 ];
 
 const projectHighlights = [

--- a/frontend/src/pages/AboutPage.jsx
+++ b/frontend/src/pages/AboutPage.jsx
@@ -1,8 +1,8 @@
 const teamMembers = [
+    'Alwin Ray Roble',
     'Alexander Leontiev',
     'Thomas Scott',
     'Nikita Ulianov',
-    'Alwin Ray Roble'
 ];
 
 const projectHighlights = [

--- a/frontend/src/pages/CatalogPage.jsx
+++ b/frontend/src/pages/CatalogPage.jsx
@@ -14,20 +14,11 @@ import IntroSection from '@components/IntroSection';
 
 function getSummarySubtitle(summaries) {
     const summaryTitles = summaries
-        .slice(0, 3)
+        .slice(0, 2)
         .map((summary) => summary?.Title?.trim())
         .filter(Boolean);
 
     return summaryTitles.length > 0 ? summaryTitles.join(' • ') : '';
-}
-
-function getSummaryPreview(summaries) {
-    const summaryBodies = summaries
-        .slice(0, 3)
-        .map((summary) => summary?.Summary?.trim())
-        .filter(Boolean);
-
-    return summaryBodies.length > 0 ? summaryBodies.join(' ') : 'No summary available';
 }
 
 export default function CatalogPage() {
@@ -90,8 +81,11 @@ export default function CatalogPage() {
                         const videoTags = tagsByMeetingId[video.MeetingID] || [];
                         const videoSummaries = summariesByMeetingId[video.MeetingID] || [];
                         const detailsLoaded = detailStatusByMeetingId[video.MeetingID]?.isSuccess;
-                        const summarySubtitle = detailsLoaded ? getSummarySubtitle(videoSummaries) : '';
-                        const summaryPreview = detailsLoaded ? getSummaryPreview(videoSummaries) : '';
+                        const summarySubtitle = detailsLoaded
+                            ? getSummarySubtitle(videoSummaries) || 'No summary available'
+                            : '';
+                        const visibleTags = videoTags.slice(0, 3);
+                        const hiddenTagCount = Math.max(videoTags.length - visibleTags.length, 0);
 
                         return (
                             <div
@@ -103,45 +97,53 @@ export default function CatalogPage() {
                                 onKeyDown={(event) => handleCardKeyDown(event, video.MeetingID, video.VideoURL)}
                             >
                                 <div className="catalog-video-card-layout">
-                                    {/* Video card title and info */}
-                                    <div className="catalog-video-meta text-start d-flex flex-column justify-content-between">
-                                        <div>
-                                            <h2 className="title mb-2">{video.Title}</h2>
-                                            {summarySubtitle && (
-                                                <p className="catalog-video-subtitle d-none d-lg-block">
-                                                    {summarySubtitle}
-                                                </p>
-                                            )}
+                                    <div className="catalog-thumbnail" title={video.Title}>
+                                        {video.ThumbnailURL ? (
+                                            <img src={video.ThumbnailURL} alt={video.Title} />
+                                        ) : (
+                                            <div className="catalog-thumbnail-fallback" aria-hidden="true">
+                                                No preview
+                                            </div>
+                                        )}
+                                        <span className="catalog-play-icon" role="img" aria-label="Play" >
+                                            <i className="fa-solid fa-circle-play"></i>
+                                        </span>
+                                    </div>
+
+                                    <div className="catalog-video-meta text-start">
+                                        <div className="catalog-video-copy">
                                             <p className="catalog-video-date">
                                                 {formatCatalogMeetingDate(video.Date)}
                                             </p>
-                                            {videoTags.length > 0 && (
-                                                <div className="catalog-tag-list d-flex flex-wrap gap-2 mt-3">
-                                                    {videoTags.map((tag) => (
+                                            <h2 className="title catalog-video-title mb-0">{video.Title}</h2>
+                                            {summarySubtitle && (
+                                                <p className="catalog-video-subtitle mb-0">
+                                                    {summarySubtitle}
+                                                </p>
+                                            )}
+                                        </div>
+
+                                        <div className="catalog-card-footer">
+                                            {visibleTags.length > 0 && (
+                                                <div className="catalog-tag-list d-flex flex-wrap gap-2">
+                                                    {visibleTags.map((tag) => (
                                                         <span key={tag.id} className="catalog-tag">
                                                             {tag.label}
                                                         </span>
                                                     ))}
+                                                    {hiddenTagCount > 0 && (
+                                                        <span className="catalog-tag catalog-tag-overflow">
+                                                            +{hiddenTagCount}
+                                                        </span>
+                                                    )}
                                                 </div>
                                             )}
-                                        </div>
-                                    </div>
 
-                                    {/* summary preview */}
-                                    {summaryPreview && (
-                                        <div className="catalog-summary-preview d-none d-lg-flex">
-                                            <p className="catalog-summary-preview-text mb-0">
-                                                {summaryPreview}
-                                            </p>
+                                            <span className="catalog-watch-cue">
+                                                <i className="fa-solid fa-circle-play" aria-hidden="true"></i>
+                                                Watch meeting
+                                            </span>
                                         </div>
-                                    )}
-
-                                    {/* video thumbnail */}
-                                    <div className="catalog-thumbnail" title={video.Title}>
-                                        <img src={video.ThumbnailURL} alt={video.Title} />
-                                        <span className="catalog-play-icon" role="img" aria-label="Play" >
-                                            <i className="fa-solid fa-circle-play"></i>
-                                        </span>
                                     </div>
                                 </div>
                             </div>

--- a/frontend/src/pages/CatalogPage.jsx
+++ b/frontend/src/pages/CatalogPage.jsx
@@ -21,6 +21,86 @@ function getSummarySubtitle(summaries) {
     return summaryTitles.length > 0 ? summaryTitles.join(' • ') : '';
 }
 
+function getCatalogTopicLine(summaries, detailsLoaded) {
+    if (!detailsLoaded) return '';
+    if (summaries.length === 0) return 'No summary available';
+
+    return getSummarySubtitle(summaries);
+}
+
+export function CatalogMeetingCard({
+    video,
+    videoTags = [],
+    videoSummaries = [],
+    detailsLoaded = false,
+    onOpen,
+}) {
+    const summarySubtitle = getCatalogTopicLine(videoSummaries, detailsLoaded);
+
+    const handleKeyDown = (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            onOpen(video.MeetingID, video.VideoURL);
+        }
+    };
+
+    return (
+        <div
+            className="video-card catalog-video-card"
+            role="button"
+            tabIndex={0}
+            onClick={() => onOpen(video.MeetingID, video.VideoURL)}
+            onKeyDown={handleKeyDown}
+        >
+            <div className="catalog-video-card-layout">
+                <div className="catalog-thumbnail" title={video.Title}>
+                    {video.ThumbnailURL ? (
+                        <img src={video.ThumbnailURL} alt={video.Title} />
+                    ) : (
+                        <div className="catalog-thumbnail-fallback" aria-hidden="true">
+                            No preview
+                        </div>
+                    )}
+                    <span className="catalog-play-icon" aria-hidden="true">
+                        <i className="fa-solid fa-circle-play"></i>
+                    </span>
+                </div>
+
+                <div className="catalog-video-meta text-start">
+                    <div className="catalog-video-copy">
+                        <p className="catalog-video-date">
+                            {formatCatalogMeetingDate(video.Date)}
+                        </p>
+                        <h2 className="title catalog-video-title mb-0">{video.Title}</h2>
+                        {summarySubtitle && (
+                            <p className="catalog-video-subtitle mb-0">
+                                {summarySubtitle}
+                            </p>
+                        )}
+                    </div>
+
+                    <div className="catalog-card-footer">
+                        {videoTags.length > 0 && (
+                            <div className="catalog-tag-list d-flex flex-wrap gap-2">
+                                {videoTags.map((tag) => (
+                                    <span key={tag.id} className="catalog-tag">
+                                        {tag.label}
+                                    </span>
+                                ))}
+                            </div>
+                        )}
+
+                        <span className="catalog-watch-cue">
+                            <i className="fa-solid fa-circle-play" aria-hidden="true"></i>
+                            Watch meeting
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
 export default function CatalogPage() {
     const [dateOrder, setDateOrder] = useState('desc');
     const [search, setSearch] = useState('');
@@ -43,13 +123,6 @@ export default function CatalogPage() {
 
     const handleButtonClick = (videoId, videoUrl) => {
         navigate (`/watch/${videoId}`, { state: { videoId, videoUrl } });
-    };
-
-    const handleCardKeyDown = (event, videoId, videoUrl) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-            event.preventDefault();
-            handleButtonClick(videoId, videoUrl);
-        }
     };
 
     const scrollToFilters = () => {
@@ -81,72 +154,16 @@ export default function CatalogPage() {
                         const videoTags = tagsByMeetingId[video.MeetingID] || [];
                         const videoSummaries = summariesByMeetingId[video.MeetingID] || [];
                         const detailsLoaded = detailStatusByMeetingId[video.MeetingID]?.isSuccess;
-                        const summarySubtitle = detailsLoaded
-                            ? getSummarySubtitle(videoSummaries) || 'No summary available'
-                            : '';
-                        const visibleTags = videoTags.slice(0, 3);
-                        const hiddenTagCount = Math.max(videoTags.length - visibleTags.length, 0);
 
                         return (
-                            <div
-                                className="video-card catalog-video-card"
+                            <CatalogMeetingCard
                                 key={video.MeetingID}
-                                role="button"
-                                tabIndex={0}
-                                onClick={() => handleButtonClick(video.MeetingID, video.VideoURL)}
-                                onKeyDown={(event) => handleCardKeyDown(event, video.MeetingID, video.VideoURL)}
-                            >
-                                <div className="catalog-video-card-layout">
-                                    <div className="catalog-thumbnail" title={video.Title}>
-                                        {video.ThumbnailURL ? (
-                                            <img src={video.ThumbnailURL} alt={video.Title} />
-                                        ) : (
-                                            <div className="catalog-thumbnail-fallback" aria-hidden="true">
-                                                No preview
-                                            </div>
-                                        )}
-                                        <span className="catalog-play-icon" role="img" aria-label="Play" >
-                                            <i className="fa-solid fa-circle-play"></i>
-                                        </span>
-                                    </div>
-
-                                    <div className="catalog-video-meta text-start">
-                                        <div className="catalog-video-copy">
-                                            <p className="catalog-video-date">
-                                                {formatCatalogMeetingDate(video.Date)}
-                                            </p>
-                                            <h2 className="title catalog-video-title mb-0">{video.Title}</h2>
-                                            {summarySubtitle && (
-                                                <p className="catalog-video-subtitle mb-0">
-                                                    {summarySubtitle}
-                                                </p>
-                                            )}
-                                        </div>
-
-                                        <div className="catalog-card-footer">
-                                            {visibleTags.length > 0 && (
-                                                <div className="catalog-tag-list d-flex flex-wrap gap-2">
-                                                    {visibleTags.map((tag) => (
-                                                        <span key={tag.id} className="catalog-tag">
-                                                            {tag.label}
-                                                        </span>
-                                                    ))}
-                                                    {hiddenTagCount > 0 && (
-                                                        <span className="catalog-tag catalog-tag-overflow">
-                                                            +{hiddenTagCount}
-                                                        </span>
-                                                    )}
-                                                </div>
-                                            )}
-
-                                            <span className="catalog-watch-cue">
-                                                <i className="fa-solid fa-circle-play" aria-hidden="true"></i>
-                                                Watch meeting
-                                            </span>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
+                                video={video}
+                                videoTags={videoTags}
+                                videoSummaries={videoSummaries}
+                                detailsLoaded={detailsLoaded}
+                                onOpen={handleButtonClick}
+                            />
                         );
                     })
                 ) : (

--- a/frontend/tests/unit/catalogMeetingCard.test.jsx
+++ b/frontend/tests/unit/catalogMeetingCard.test.jsx
@@ -1,0 +1,69 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, test } from 'vitest';
+
+import { CatalogMeetingCard } from '../../src/pages/CatalogPage.jsx';
+
+const baseVideo = {
+    MeetingID: 1,
+    Title: 'Regular Council Meeting',
+    Date: '2025-01-02',
+    VideoURL: 'https://www.youtube.com/watch?v=abc123',
+    ThumbnailURL: 'https://i.ytimg.com/vi/abc123/hq720.jpg',
+};
+
+function renderCard(props = {}) {
+    return renderToStaticMarkup(
+        <CatalogMeetingCard
+            video={props.video || baseVideo}
+            videoTags={props.videoTags || []}
+            videoSummaries={props.videoSummaries || []}
+            detailsLoaded={props.detailsLoaded ?? true}
+            onOpen={() => {}}
+        />,
+    );
+}
+
+describe('CatalogMeetingCard', () => {
+    test('renders provided tags directly without an overflow badge', () => {
+        const html = renderCard({
+            videoTags: [
+                { id: 'budget', label: 'Budget' },
+                { id: 'housing', label: 'Housing' },
+                { id: 'transportation', label: 'Transportation' },
+                { id: 'parks', label: 'Parks & Rec' },
+            ],
+        });
+
+        expect(html).toContain('Budget');
+        expect(html).toContain('Housing');
+        expect(html).toContain('Transportation');
+        expect(html).toContain('Parks &amp; Rec');
+        expect(html).not.toContain('>+1<');
+    });
+
+    test('shows no-summary fallback only when details loaded with zero summaries', () => {
+        expect(renderCard({ videoSummaries: [], detailsLoaded: true })).toContain('No summary available');
+        expect(renderCard({ videoSummaries: [], detailsLoaded: false })).not.toContain('No summary available');
+    });
+
+    test('does not render summary bodies or false fallback when summary titles are missing', () => {
+        const html = renderCard({
+            videoSummaries: [{ Summary: 'This long summary body should stay off the catalog card.' }],
+        });
+
+        expect(html).not.toContain('This long summary body should stay off the catalog card.');
+        expect(html).not.toContain('No summary available');
+    });
+
+    test('renders missing-thumbnail fallback and watch cue', () => {
+        const html = renderCard({
+            video: {
+                ...baseVideo,
+                ThumbnailURL: null,
+            },
+        });
+
+        expect(html).toContain('No preview');
+        expect(html).toContain('Watch meeting');
+    });
+});


### PR DESCRIPTION
## Overview
This branch refreshes the catalog meeting cards into a cleaner, more compact digest layout focused on faster scanning.

## Changes
- Updated catalog cards to show thumbnail, date, title, short topic line, tags, and a Watch meeting cue.
- Removed the long summary preview from each card.
- Added a fallback display for meetings without a thumbnail.
- Removed unreachable tag overflow logic and unused overflow CSS.
- Tightened summary fallback behavior so No summary available only appears when details are loaded and no summaries exist.
- Made the thumbnail play overlay decorative for screen readers.
- Added unit tests for card rendering behavior.

## Notes
- The whole card remains clickable and keyboard accessible.
- Tag inference still caps meetings at 3 tags upstream.
- The branch also reverts an unrelated About page ordering change so the diff stays focused.