### PR TITLE
Drop whisperx batch_size to 8; document chained cron entry

### DIFF
--- a/Models/config.yaml
+++ b/Models/config.yaml
@@ -24,3 +24,9 @@ meeting_year: 2026
 # Hopper). On Pascal (e.g. Tesla P40), use "int8" — FP16 isn't efficient
 # below sm_70 and ctranslate2 will refuse it.
 compute_type: "int8"
+
+# Whisperx parallel-chunk batch size. 16 fits a 24GB GPU on its own, but
+# the dev/prod Ollama containers each pin ~4GB for qwen3-embedding under
+# the 24h keep-alive — so we drop to 8 to leave headroom and avoid OOM
+# when the pipeline's summary stage also loads llama3.1:8b mid-run.
+batch_size: "8"

--- a/Models/scripts/run_if_new.sh
+++ b/Models/scripts/run_if_new.sh
@@ -32,8 +32,14 @@
 #       /home/overseer/civiclens-pipeline/.venv/bin/council-pipeline --init-db
 #
 # ─── Cron entry (after bring-up) ──────────────────────────────────────────
+# Chain dev + prod sequentially in one entry. The wrapper's flock means
+# back-to-back invocations against the same lock file run in series; the `;`
+# (rather than `&&`) ensures prod still runs if dev fails.
+#
 #   0 */2 * * * /home/overseer/test/CivicLens/Models/scripts/run_if_new.sh \
-#       /home/overseer/config/civiclens-dev.env
+#       /home/overseer/config/civiclens-dev.env; \
+#     /home/overseer/test/CivicLens/Models/scripts/run_if_new.sh \
+#       /home/overseer/config/civiclens-prod.env
 
 set -euo pipefail
 


### PR DESCRIPTION
batch_size=16 OOMs on a 24GB GPU now that OLLAMA_KEEP_ALIVE=24h pins the chatbot's qwen3-embedding model in VRAM (~4GB) on each Ollama container. 8 leaves headroom for whisperx + pyannote + the pipeline's own llama3.1:8b summary load (~5GB).

Also updated the wrapper's cron-entry example to show dev+prod chained in a single entry, since separating them by 30 min created a 2-hour prod-lag scenario when dev took >30 min.